### PR TITLE
cleanup usage and rename tool file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ all: ectoken libectoken.a
 # ------------------------------------------------------------------------------
 # ectoken
 # ------------------------------------------------------------------------------
-ectoken: util/ec_encrypt.c ectoken.c base64.c
-	gcc -O2 -Wall -Werror -std=gnu99 util/ec_encrypt.c -I. ectoken.c base64.c -o ectoken $(OPENSSL_LIBS) $(OPENSSL_INCLUDE) -lm
+ectoken: util/ectoken_cmd.c ectoken.c base64.c
+	gcc -O2 -Wall -Werror -std=gnu99 util/ectoken_cmd.c -I. ectoken.c base64.c -o ectoken $(OPENSSL_LIBS) $(OPENSSL_INCLUDE) -lm
 # ------------------------------------------------------------------------------
 # libectoken
 # ------------------------------------------------------------------------------

--- a/util/ectoken_cmd.c
+++ b/util/ectoken_cmd.c
@@ -31,11 +31,11 @@ int print_usage(void)
 {
         printf("Usage: \n");
         printf(" To Encrypt:\n");
-        printf("     ec_encrypt <key> <text>\n");
+        printf("     ectoken <key> <text>\n");
         printf(" or:\n");
-        printf("     ec_encrypt encrypt <key> <text>\n");
+        printf("     ectoken encrypt <key> <text>\n");
         printf(" To Decrypt:\n");
-        printf("     ec_encrypt decrypt <key> <text>\n");
+        printf("     ectoken decrypt <key> <text>\n");
         return 0;
 }
 //! ----------------------------------------------------------------------------


### PR DESCRIPTION
### What
- fix usage to match "tool" name (`ectoken`)
- rename "tool" implementation file to `ectoken_cmd`